### PR TITLE
move recurseOnStateOrBelief/fastUpdateBelief into agent

### DIFF
--- a/src/beliefAgent.wppl
+++ b/src/beliefAgent.wppl
@@ -10,9 +10,6 @@
 // has had manifest states removed.
 
 
-// Optimizations that work in bandits and gridworld (not for boundVOI agent)
-var recurseOnStateOrBelief = 'belief';
-var fastUpdateBelief = true;
 
 
 
@@ -131,6 +128,9 @@ var makeBeliefAgent = function(params, world) {
       ['utility','alpha', 'priorBelief']);
   assert.ok( isPOMDPWorld(world),
 	     'world argument lacks transition, stateToActions, or observe');
+
+  //set defaults for optimizations
+  var params = update({ recurseOnStateOrBelief : 'belief', fastUpdateBelief : true}, params);
   
   var utility = params.utility;
   var manifestStateToActions = world.manifestStateToActions;
@@ -138,9 +138,14 @@ var makeBeliefAgent = function(params, world) {
   var worldObserve = world.observe;
   var observe = getFullObserve(worldObserve);
   var beliefToActions = getBeliefToActions( manifestStateToActions );
+
+  // Optimizations that work in bandits and gridworld (not for boundVOI agent)
+  var recurseOnStateOrBelief = params.recurseOnStateOrBelief;
+  var fastUpdateBelief = params.fastUpdateBelief;
   
   var updateBelief = fastUpdateBelief ? getUpdateBeliefLatent(transition, observe) :
       getUpdateBeliefSimple(transition, observe);
+
 
   
   // RECURSE ON BELIEF (BELLMAN STYLE)

--- a/src/beliefDelayAgent.wppl
+++ b/src/beliefDelayAgent.wppl
@@ -35,6 +35,8 @@ var makeBeliefDelayAgent = function (params, world){
     'myopia and boundVOI require Naive agent with delays');
   }
 
+  var params = update({ recurseOnStateOrBelief : 'belief', fastUpdateBelief : true}, params);
+
   // Variables for methods
   var transition = world.transition;
   var utility = params.utility;
@@ -43,6 +45,10 @@ var makeBeliefDelayAgent = function (params, world){
   var worldObserve = world.observe;
   var observe = getFullObserve(worldObserve);
   var beliefToActions = getBeliefToActions( manifestStateToActions );
+
+  // Optimizations that work in bandits and gridworld (not for boundVOI agent)
+  var recurseOnStateOrBelief = params.recurseOnStateOrBelief;
+  var fastUpdateBelief = params.fastUpdateBelief;
   
 
   // Update the *delay* parameter in *expectedUtility* for sampling actions and future utilities


### PR DESCRIPTION
Seems like these optimization flags should be inside agent. Or is there some reason they were outside?
